### PR TITLE
bug: append vapid and encryption headers with a ';'

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -176,7 +176,10 @@ class WebPusher:
         headers = CaseInsensitiveDict(headers)
         crypto_key = headers.get("crypto-key", "")
         if crypto_key:
-            crypto_key += ','
+            # due to some confusion by a push service provider, we should
+            # use ';' instead of ',' to append the headers.
+            # see https://github.com/webpush-wg/webpush-encryption/issues/6
+            crypto_key += ';'
         crypto_key += "keyid=p256dh;dh=" + encoded["crypto_key"].decode('utf8')
         headers.update({
             'crypto-key': crypto_key,

--- a/pywebpush/tests/test_webpush.py
+++ b/pywebpush/tests/test_webpush.py
@@ -106,7 +106,7 @@ class WebpushTestCase(unittest.TestCase):
         ok_('encryption' in pheaders)
         eq_(pheaders.get('AUTHENTICATION'), headers.get('Authentication'))
         ckey = pheaders.get('crypto-key')
-        ok_('pre-existing,' in ckey)
+        ok_('pre-existing' in ckey)
         eq_(pheaders.get('content-encoding'), 'aesgcm')
 
     def test_ci_dict(self):


### PR DESCRIPTION
FCM, unfortunately, rejects multiple parameter sets for Crypto-Key.
This is a work-around fix until the issue is properly resolved by the
respective working groups.

closes #8