### PR TITLE
Updating docstring for WebPusher.send method

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -158,8 +158,6 @@ class WebPusher:
         :param data: A serialized block of data (see encode() ).
         :param gcm_key: API key obtained from the Google Developer Console.
             Needed if endpoint is https://android.googleapis.com/gcm/send
-        :param reg_id: registration id of the recipient. If not provided,
-            it will be extracted from the endpoint.
         :param headers: A dictionary containing any additional HTTP headers.
         :param ttl: The Time To Live in seconds for this message if the
             recipient is not online. (Defaults to "0", which discards the


### PR DESCRIPTION
Removed duplicate description for :param reg_id: in WebPusher.send method docstring.