### PR TITLE
Facilitate easier use of another networking library

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -209,6 +209,15 @@ class WebPusher:
             headers['ttl'] = ttl
         # Additionally useful headers:
         # Authorization / Crypto-Key (VAPID headers)
-        return requests.post(endpoint,
-                             data=encoded_data,
+        return self._post(endpoint, encoded_data, headers)
+
+    def _post(self, url, data, headers):
+        """Make POST request on specified Web Push endpoint with given data
+        and headers.
+
+        Subclass this class and override this method if you want to use any
+        other networking library or interface and keep the business logic.
+        """
+        return requests.post(url,
+                             data=data,
                              headers=headers)


### PR DESCRIPTION
Hi, there!

Great library, really simple to use.

I'm trying to use it with new Python 3.5 asyncio network library and it's proving tedious to have to copy-paste the whole ```send``` method in order to change just the last line, where the method calls ```requests.post```. This pull request changes ```requests.post``` call into call to ```self._post```, which makes it easy to subclass and override method ```_post``` and use another networking library if one wishes, keeping the business logic the same.

There are no backwards incompatible changes. The default is still requests, test coverage is still at 100%. I tested the library on Python 2.7, PyPy and Python 3.5. 

