### PR TITLE
Fix RST in README.rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build_Status](https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master)](https://travis-ci.org/web-push-libs/pywebpush)
+[![Build Status](https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master)](https://travis-ci.org/web-push-libs/pywebpush)
 [![Requirements
 Status](https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=feat%2F44)](https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master)](https://travis-ci.org/web-push-libs/pywebpush)
 [![Requirements
-Status](https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=feat%2F44)](https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master)
+Status](https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=master](https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master)
 
 # Webpush Data encryption library for Python
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build\_Status| |Requirements Status|
+|Build Status| |Requirements Status|
 
 Webpush Data encryption library for Python
 ==========================================
@@ -170,7 +170,7 @@ Encode the ``data`` for future use. On error, returns a
 
     encoded_data = WebPush(subscription_info).encode(data)
 
-.. |Build\_Status| image:: https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master
+.. |Build Status| image:: https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master
    :target: https://travis-ci.org/web-push-libs/pywebpush
 .. |Requirements Status| image:: https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=feat%2F44
    :target: https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master

--- a/README.rst
+++ b/README.rst
@@ -172,5 +172,5 @@ Encode the ``data`` for future use. On error, returns a
 
 .. |Build Status| image:: https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master
    :target: https://travis-ci.org/web-push-libs/pywebpush
-.. |Requirements Status| image:: https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=feat%2F44
+.. |Requirements Status| image:: https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=master
    :target: https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master


### PR DESCRIPTION
This should hopefully make the PyPI page pretty again once the next release is published.

Here's how I caught the error:

```
$ rstcheck README.rst
README.rst:1: (ERROR/3) Undefined substitution referenced: "Build_Status".
```