### PR TITLE
feat: update to use Cryptography library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Build_Status](https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master)](https://travis-ci.org/web-push-libs/pywebpush)
+[![Build
+Status](https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master)](https://travis-ci.org/web-push-libs/pywebpush)
 [![Requirements
-Status](https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=feat%2F44)](https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master)
+Status](https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=master)](https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master)
 
 # Webpush Data encryption library for Python
 
@@ -61,8 +62,12 @@ in the `subscription_info` block.
 *data* - can be any serial content (string, bit array, serialized JSON, etc), but be sure that your receiving
 application is able to parse and understand it. (e.g. `data = "Mary had a little lamb."`)
 
+*content_type* - specifies the form of Encryption to use, either `'aesgcm'` or the newer `'aes128gcm'`. NOTE that 
+not all User Agents can decrypt `'aes128gcm'`, so the library defaults to the older form.
+
 *vapid_claims* - a `dict` containing the VAPID claims required for authorization (See
-[py_vapid](https://github.com/web-push-libs/vapid/tree/master/python) for more details)
+[py_vapid](https://github.com/web-push-libs/vapid/tree/master/python) for more details). If `aud` is not specified,
+pywebpush will attempt to auto-fill from the `endpoint`.
 
 *vapid_private_key* - Either a path to a VAPID EC2 private key PEM file, or a string containing the DER representation.
 (See [py_vapid](https://github.com/web-push-libs/vapid/tree/master/python) for more details.) The `private_key` may be

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build\_Status| |Requirements Status|
+|Build Status| |Requirements Status|
 
 Webpush Data encryption library for Python
 ==========================================
@@ -65,10 +65,15 @@ above).
 etc), but be sure that your receiving application is able to parse and
 understand it. (e.g. ``data = "Mary had a little lamb."``)
 
+*content\_type* - specifies the form of Encryption to use, either
+``'aesgcm'`` or the newer ``'aes128gcm'``. NOTE that not all User Agents
+can decrypt ``'aes128gcm'``, so the library defaults to the older form.
+
 *vapid\_claims* - a ``dict`` containing the VAPID claims required for
 authorization (See
 `py\_vapid <https://github.com/web-push-libs/vapid/tree/master/python>`__
-for more details)
+for more details). If ``aud`` is not specified, pywebpush will attempt
+to auto-fill from the ``endpoint``.
 
 *vapid\_private\_key* - Either a path to a VAPID EC2 private key PEM
 file, or a string containing the DER representation. (See
@@ -170,7 +175,7 @@ Encode the ``data`` for future use. On error, returns a
 
     encoded_data = WebPush(subscription_info).encode(data)
 
-.. |Build\_Status| image:: https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master
+.. |Build Status| image:: https://travis-ci.org/web-push-libs/pywebpush.svg?branch=master
    :target: https://travis-ci.org/web-push-libs/pywebpush
-.. |Requirements Status| image:: https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=feat%2F44
+.. |Requirements Status| image:: https://requires.io/github/web-push-libs/pywebpush/requirements.svg?branch=master
    :target: https://requires.io/github/web-push-libs/pywebpush/requirements/?branch=master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-http-ece==0.7.1
-python-jose==1.3.2
+cryptography==1.8.1
+http-ece==1.0.1
 requests==2.13.0
-py-vapid==0.8.1
+py-vapid==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = "0.8.0"
+__version__ = "1.0.0"
 
 
 def read_from(file):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 nose>=1.3.7
-coverage>=4.3.4
+coverage>=4.4
 mock==2.0.0
 flake8


### PR DESCRIPTION
* uses lastest ece(1.7.2) and vapid libraries (1.2.1)
* Will attempt to autofill vapid `aud` from the endpoint if VAPID
requested
* Allows for the older `'aesgcm'` and newer, albeit not as widely
supported `'aes128gcm'` encryption content types.
* Includes fixes provided by https://github.com/Flimm

closes: #49, #48, #42
Includes: #50, #51, #52