### PR TITLE
as_curl() content-length typo fix

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -210,7 +210,7 @@ class WebPusher:
             data = "--data-binary @encrypted.data"
         if 'content-length' not in headers:
             header_list.append(
-                '-H "content-length: {}" \\ \n'.format(len(data)))
+                '-H "content-length: {}" \\ \n'.format(len(encoded_data) if encoded_data else 0))
         return ("""curl -vX POST {url} \\\n{headers}{data}""".format(
             url=endpoint, headers="".join(header_list), data=data))
 

--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -209,8 +209,9 @@ class WebPusher:
                 f.write(encoded_data)
             data = "--data-binary @encrypted.data"
         if 'content-length' not in headers:
+            content_length = len(encoded_data) if encoded_data else 0
             header_list.append(
-                '-H "content-length: {}" \\ \n'.format(len(encoded_data) if encoded_data else 0))
+                '-H "content-length: {}" \\ \n'.format(content_length))
         return ("""curl -vX POST {url} \\\n{headers}{data}""".format(
             url=endpoint, headers="".join(header_list), data=data))
 


### PR DESCRIPTION
The "Content-Length" transmitted with the curl request should be the length of the encoded data, not the length of the "--data-binary ..." command line parameter.