### PR TITLE
add requests timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ can pass just `wp = WebPusher(subscription_info)`. This will return a `WebPusher
 
 The following methods are available:
 
-#### `.send(data, headers={}, ttl=0, gcm_key="", reg_id="", content_encoding="aesgcm", curl=False)`
+#### `.send(data, headers={}, ttl=0, gcm_key="", reg_id="", content_encoding="aesgcm", curl=False, timeout=None)`
 
 Send the data using additional parameters. On error, returns a `WebPushException`
 
@@ -133,6 +133,9 @@ Developer Console.
 
 *curl* Do not execute the POST, but return as a `curl` command. This will write the encrypted content to a local file
 named `encrpypted.data`. This command is meant to be used for debugging purposes.
+
+*timeout* timeout for requests POST query.
+See [requests documentation](http://docs.python-requests.org/en/master/user/quickstart/#timeouts).
 
 **Example**
 

--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -212,7 +212,7 @@ class WebPusher:
             url=endpoint, headers="".join(header_list), data=data))
 
     def send(self, data=None, headers=None, ttl=0, gcm_key=None, reg_id=None,
-             content_encoding="aesgcm", curl=False):
+             content_encoding="aesgcm", curl=False, timeout=None):
         """Encode and send the data to the Push Service.
 
         :param data: A serialized block of data (see encode() ).
@@ -233,6 +233,8 @@ class WebPusher:
         :type content_encoding: str
         :param curl: Display output as `curl` command instead of sending
         :type curl: bool
+        :param timeout: POST requests timeout
+        :type timeout: float or tuple
 
         """
         # Encode the data.
@@ -285,7 +287,8 @@ class WebPusher:
             return self.as_curl(endpoint, encoded_data, headers)
         return requests.post(endpoint,
                              data=encoded_data,
-                             headers=headers)
+                             headers=headers,
+                             timeout=timeout)
 
 
 def webpush(subscription_info,
@@ -293,7 +296,8 @@ def webpush(subscription_info,
             vapid_private_key=None,
             vapid_claims=None,
             content_encoding="aesgcm",
-            curl=False):
+            curl=False,
+            timeout=None):
     """
         One call solution to endcode and send `data` to the endpoint
         contained in `subscription_info` using optional VAPID auth headers.
@@ -330,6 +334,8 @@ def webpush(subscription_info,
     :type content_encoding: str
     :param curl: Return as "curl" string instead of sending
     :type curl: bool
+    :param timeout: POST requests timeout
+    :type timeout: float or tuple
     :return requests.Response or string
 
     """
@@ -354,6 +360,7 @@ def webpush(subscription_info,
         vapid_headers,
         content_encoding=content_encoding,
         curl=curl,
+        timeout=timeout,
     )
     if not curl and result.status_code > 202:
         raise WebPushException("Push failed: {}: {}".format(

--- a/pywebpush/tests/test_webpush.py
+++ b/pywebpush/tests/test_webpush.py
@@ -294,3 +294,13 @@ class WebpushTestCase(unittest.TestCase):
         eq_(pdata["registration_ids"][0], "regid123")
         eq_(pheaders.get("authorization"), "key=gcm_key_value")
         eq_(pheaders.get("content-type"), "application/json")
+
+    @patch("requests.post")
+    def test_timeout(self, mock_post):
+        mock_post.return_value = Mock()
+        mock_post.return_value.status_code = 200
+        subscription_info = self._gen_subscription_info()
+        WebPusher(subscription_info).send(timeout=5.2)
+        eq_(mock_post.call_args[1].get('timeout'), 5.2)
+        webpush(subscription_info, timeout=10.001)
+        eq_(mock_post.call_args[1].get('timeout'), 10.001)


### PR DESCRIPTION
Hi,

This pull request allows users to set the requests timeout parameter when sending a push. I think it is important for all production code to prevent lock to happen.

If you are ok to merge this, could you make a minor release quickly on pypi ?

Thanks