### PR TITLE
add python 3.4 and 3.5 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
   - "3.6"
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Hi,

I am using this package on python 3.4. It works fine. So just to be sure that nothing break if somebody makes any change, I think it would be useful. Moreover it does no harm to add this :)

Thanks