### PR TITLE
webpush(): Allow passing Vapid instance 

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -326,8 +326,9 @@ def webpush(subscription_info,
     :type subscription_info: dict
     :param data: Serialized data to send
     :type data: str
-    :param vapid_private_key: Path to vapid private key PEM or encoded str
-    :type vapid_private_key: str
+    :param vapid_private_key: Vapid instance or path to vapid private key PEM \
+                              or encoded str
+    :type vapid_private_key: Union[Vapid, str]
     :param vapid_claims: Dictionary of claims ('sub' required)
     :type vapid_claims: dict
     :param content_encoding: Optional content type string
@@ -347,7 +348,9 @@ def webpush(subscription_info,
             vapid_claims['aud'] = aud
         if not vapid_private_key:
             raise WebPushException("VAPID dict missing 'private_key'")
-        if os.path.isfile(vapid_private_key):
+        if isinstance(vapid_private_key, Vapid):
+            vv = vapid_private_key
+        elif os.path.isfile(vapid_private_key):
             # Presume that key from file is handled correctly by
             # py_vapid.
             vv = Vapid.from_file(

--- a/pywebpush/tests/test_webpush.py
+++ b/pywebpush/tests/test_webpush.py
@@ -3,7 +3,7 @@ import json
 import os
 import unittest
 
-from mock import patch, Mock
+from mock import patch
 from nose.tools import eq_, ok_, assert_raises
 import http_ece
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -138,7 +138,6 @@ class WebpushTestCase(unittest.TestCase):
 
     @patch("requests.post")
     def test_send_vapid(self, mock_post):
-        mock_post.return_value = Mock()
         mock_post.return_value.status_code = 200
         subscription_info = self._gen_subscription_info()
         data = "Mary had a little lamb"
@@ -170,7 +169,6 @@ class WebpushTestCase(unittest.TestCase):
 
     @patch("requests.post")
     def test_send_bad_vapid_no_key(self, mock_post):
-        mock_post.return_value = Mock()
         mock_post.return_value.status_code = 200
 
         subscription_info = self._gen_subscription_info()
@@ -187,7 +185,6 @@ class WebpushTestCase(unittest.TestCase):
 
     @patch("requests.post")
     def test_send_bad_vapid_bad_return(self, mock_post):
-        mock_post.return_value = Mock()
         mock_post.return_value.status_code = 410
 
         subscription_info = self._gen_subscription_info()
@@ -297,7 +294,6 @@ class WebpushTestCase(unittest.TestCase):
 
     @patch("requests.post")
     def test_timeout(self, mock_post):
-        mock_post.return_value = Mock()
         mock_post.return_value.status_code = 200
         subscription_info = self._gen_subscription_info()
         WebPusher(subscription_info).send(timeout=5.2)


### PR DESCRIPTION
If the caller of `webpush()` already has a `py_vapid.Vapid` instance lying around, allow passing it as the `vapid_private_key` argument instead of forcing the developer to go back to the private key string just to regenerate a Vapid instance.