### PR TITLE
bug: update to use vapid 'from_string' function

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -353,7 +353,7 @@ def webpush(subscription_info,
             vv = Vapid.from_file(
                 private_key_file=vapid_private_key)  # pragma no cover
         else:
-            vv = Vapid.from_raw(private_raw=vapid_private_key.encode())
+            vv = Vapid.from_string(private_key=vapid_private_key)
         vapid_headers = vv.sign(vapid_claims)
     result = WebPusher(subscription_info).send(
         data,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=1.8.1,<1.10
+cryptography>=1.8.1
 http-ece>=1.0.1
 requests>=2.13.0
-py-vapid>=1.2.5
+py-vapid>=1.3.0


### PR DESCRIPTION
remove crypto upper version limit
bump py-vapid base version