### PR TITLE
Copy subscription before altering the keys.

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import base64
+from copy import deepcopy
 import json
 import os
 
@@ -116,7 +117,7 @@ class WebPusher:
 
         if 'endpoint' not in subscription_info:
             raise WebPushException("subscription_info missing endpoint URL")
-        self.subscription_info = subscription_info
+        self.subscription_info = deepcopy(subscription_info)
         self.auth_key = self.receiver_key = None
         if 'keys' in subscription_info:
             keys = self.subscription_info['keys']

--- a/pywebpush/tests/test_webpush.py
+++ b/pywebpush/tests/test_webpush.py
@@ -4,7 +4,7 @@ import os
 import unittest
 
 from mock import patch
-from nose.tools import eq_, ok_, assert_raises
+from nose.tools import eq_, ok_, assert_is_not, assert_raises
 import http_ece
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.backends import default_backend
@@ -75,7 +75,10 @@ class WebpushTestCase(unittest.TestCase):
              "keys": {'p256dh': 'AAA=', 'auth': 'AAA='}})
 
         push = WebPusher(subscription_info)
-        eq_(push.subscription_info, subscription_info)
+        assert_is_not(push.subscription_info, subscription_info)
+        assert_is_not(push.subscription_info['keys'],
+                      subscription_info['keys'])
+        eq_(push.subscription_info['endpoint'], subscription_info['endpoint'])
         eq_(push.receiver_key, rk_decode)
         eq_(push.auth_key, b'\x93\xc2U\xea\xc8\xddn\x10"\xd6}\xff,0K\xbc')
 


### PR DESCRIPTION
Altering subscriptions reference by changing the keys from string to
byte causes hard to debug issues in libraries. For exemple, trying to
call `json.dumps()` after initializing `WebPusher` throws an error
because json cannot handle bytes.