### PR TITLE
Select legacy GCM or actual FCM endpoint for send based on the gcm_key

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -309,7 +309,7 @@ class WebPusher:
             })
         if gcm_key:
             # guess if it is a legacy GCM project key or actual FCM key
-            # gcm keys are all about 40 chars (use 100 for confidence), 
+            # gcm keys are all about 40 chars (use 100 for confidence),
             # fcm keys are 153-175 chars
             if len(gcm_key) < 100:
                 endpoint = 'https://android.googleapis.com/gcm/send'

--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -308,7 +308,13 @@ class WebPusher:
                 'content-encoding': content_encoding,
             })
         if gcm_key:
-            endpoint = 'https://android.googleapis.com/gcm/send'
+            # guess if it is a legacy GCM project key or actual FCM key
+            # gcm keys are all about 40 chars (use 100 for confidence), 
+            # fcm keys are 153-175 chars
+            if len(gcm_key) < 100:
+                endpoint = 'https://android.googleapis.com/gcm/send'
+            else:
+                endpoint = 'https://fcm.googleapis.com/fcm/send'
             reg_ids = []
             if not reg_id:
                 reg_id = self.subscription_info['endpoint'].rsplit('/', 1)[-1]


### PR DESCRIPTION
Hello,

As https://developers.google.com/cloud-messaging/android/android-migrate-fcm states: "As of April 10, 2018, Google has deprecated GCM. The GCM server and client APIs are deprecated and will be removed as soon as May 29, 2019." 
So after may 29th posting to https://android.googleapis.com/gcm/send will not work.

But, as far as I understand, we can't just change line 311 to:
```
endpoint = 'https://fcm.googleapis.com/fcm/send'
```
as stated in paragraph 4 of android-migrate-fcm, because endusers of the pywebpush lib have to manually Import their GCM projects as a Firebase projects and receive new key (paragraph 1). Just changing the endpoint will break sending for those who still haven't switched from GCM to FCM even before May 29.



