### PR TITLE
bug: update minimum vapid requirement to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # I am terrible at keeping this up-to-date.
 
+## 1.10.2 (2020-04-11)
+bug: update min vapid requirement to 1.7.0
+
 ## 1.10.1 (2019-12-03)
 feat: use six.text_type instead of six.string_types
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cryptography>=2.6.1
 http-ece>=1.1.0
 requests>=2.21.0
-py-vapid>=1.5.0
+py-vapid>=1.7.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import find_packages, setup
 
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 
 
 def read_from(file):


### PR DESCRIPTION
Closes #121