### PR TITLE
Fix missing six requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cryptography>=2.6.1
 http-ece>=1.1.0
 requests>=2.21.0
+six>=1.15.0
 py-vapid>=1.7.0


### PR DESCRIPTION
After a fresh install

```
$ python3 -m venv venv
$ . venv/bin/activate
$ pip3 install pywebpush
```

pywebpush fails with a missing dependency:

```
$ python3 -c "import pywebpush"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pywebpush/pywebpush/__init__.py", line 16, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```

six was never listed in `requirements.txt`, so my guess would be that so far it has been installed by an upstream dependency, which recently dropped it.

This small fix adds six to `requirements.txt`.

Thanks so much for your work on pywebpush! :blush: 