### PR TITLE
Support requests_session param in webpush fn too

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -382,6 +382,7 @@ def webpush(subscription_info,
             curl=False,
             timeout=None,
             ttl=0,
+            requests_session=None,
             verbose=False,
             headers=None):
     """
@@ -473,7 +474,7 @@ def webpush(subscription_info,
             print("\t headers: {}".format(vapid_headers))
         headers.update(vapid_headers)
 
-    response = WebPusher(subscription_info, verbose=verbose).send(
+    response = WebPusher(subscription_info, requests_session=requests_session, verbose=verbose).send(
         data,
         headers,
         ttl=ttl,

--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -474,7 +474,9 @@ def webpush(subscription_info,
             print("\t headers: {}".format(vapid_headers))
         headers.update(vapid_headers)
 
-    response = WebPusher(subscription_info, requests_session=requests_session, verbose=verbose).send(
+    response = WebPusher(
+        subscription_info, requests_session=requests_session, verbose=verbose
+    ).send(
         data,
         headers,
         ttl=ttl,

--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -382,9 +382,9 @@ def webpush(subscription_info,
             curl=False,
             timeout=None,
             ttl=0,
-            requests_session=None,
             verbose=False,
-            headers=None):
+            headers=None,
+            requests_session=None):
     """
         One call solution to endcode and send `data` to the endpoint
         contained in `subscription_info` using optional VAPID auth headers.


### PR DESCRIPTION
I need to inject my own request library, and also need vapid support which only seems available in the `webpush` function and not in `WebPusher.send/encode`, so it would be great to add the `requests_session` parameter to that function too.