### PR TITLE
fix accepting all Vapid key instances (#137)

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -19,7 +19,7 @@ import requests
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import serialization
-from py_vapid import Vapid
+from py_vapid import Vapid, Vapid01
 
 
 class WebPushException(Exception):
@@ -458,7 +458,7 @@ def webpush(subscription_info,
                     vapid_claims['exp']))
         if not vapid_private_key:
             raise WebPushException("VAPID dict missing 'private_key'")
-        if isinstance(vapid_private_key, Vapid):
+        if isinstance(vapid_private_key, Vapid01):
             vv = vapid_private_key
         elif os.path.isfile(vapid_private_key):
             # Presume that key from file is handled correctly by


### PR DESCRIPTION
`Vapid01` is not a subclass of `Vapid` (`Vapid02`). This change allows passing of an initialized `Vapid01` key object. Refs issue #137.