### PR TITLE
Fix #130 by copying claims dict

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -441,13 +441,14 @@ def webpush(subscription_info,
 
     vapid_headers = None
     if vapid_claims:
+        # Remember, passed structures are mutable in python.
+        vapid_claims = deepcopy(vapid_claims)
         if verbose:
             print("Generating VAPID headers...")
         if not vapid_claims.get('aud'):
             url = urlparse(subscription_info.get('endpoint'))
             aud = "{}://{}".format(url.scheme, url.netloc)
             vapid_claims['aud'] = aud
-        # Remember, passed structures are mutable in python.
         # It's possible that a previously set `exp` field is no longer valid.
         if (not vapid_claims.get('exp')
                 or vapid_claims.get('exp') < int(time.time())):


### PR DESCRIPTION
I my humble opinion modifying the `vapid_claims` dict is very unintuitive because it can lead to errors such as the one I described in #130. I therefore recommend copying the dict as implemented in this PR to avoid such errors.

It's also worth considering to revert the fix from #113 within this PR since it attempted to solve a similar problem that is also covered by this change, although that would change the behavior for `exp`s in the past a bit. The corresponding test would need to be changed.

If the modifying of the passed dict is intentional, I'd recommend making that very clear in the documentation.

Please let me know about any desired changes, I'm unfamiliar with e.g. python tests.