### PR TITLE
feat: Add `--wns` option to handle WNS header

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -424,9 +424,10 @@ class WebPusher:
             **params,
         )
         self.verb(
-            "\nResponse:\n\tcode: {}\n\tbody: {}\n",
+            "\nResponse:\n\tcode: {}\n\tbody: {}\n\theaders: {}",
             resp.status_code,
             resp.text or "Empty",
+            resp.headers or "None"
         )
         return resp
 


### PR DESCRIPTION
## Description

Microsoft has introduced [extra
header](https://learn.microsoft.com/en-us/windows/apps/design/shell/tiles-and-notifications/push-request-response-headers#request-parameters) requirements for incoming push messages. I kind of want to avoid adding a lot of system specific smarts to pywebpush, mostly because that's an endless road of feature creep. The preferred way to handle this would be to include the extra, call specific headers in the `webpush(..., headers=dict(...))` argument.

## Issue(s)

Closes #162
