### PR TITLE
fix: check if response attribute of WebPushException object is not None in __str__ method

### DIFF
--- a/pywebpush/__init__.py
+++ b/pywebpush/__init__.py
@@ -41,7 +41,7 @@ class WebPushException(Exception):
 
     def __str__(self):
         extra = ""
-        if self.response:
+        if self.response is not None:
             try:
                 extra = ", Response {}".format(
                     self.response.text,


### PR DESCRIPTION
## Description

This is a follow up to [this PR](https://github.com/web-push-libs/pywebpush/pull/168). I wanted to create separate PR for these changes as perhaps I'm not aware if something wasn't a design decision (however I have an impression that it was simply a mistake, not a design decision 😄 )

I've updated `WebPushException.__str__` method to check if `self.response` attribute is not `None` (thus is an instance of `requests.Response`) in case of adding extra `self.response` to the string representation of `WebPushException` instance.

Currently the check was relying on checking thruthiness of `self.response` attribute. Unfortunately, this won't work properly if `requests.Response` instance has status code between 400 and 599, for which `requests.Response.__bool__` method returns `False` which in turn will fail the check and won't add extra `self.response` to the string representation of `WebPushException` instance.

Checking if `self.response is not None` works properly.

Example:

```python
class WebPushException(Exception):
    """Web Push failure.

    This may contain the requests.Response

    """

    def __init__(self, message, response=None):
        self.message = message
        self.response = response

    def __str__(self):
        extra = ""
        if self.response is not None:
            try:
                extra = ", Response {}".format(
                    self.response.text,
                )
            except AttributeError:
                extra = ", Response {}".format(self.response)
        return "WebPushException: {}{}".format(self.message, extra)

response = Response()
response.status_code = 401
response._content = "response content".encode()
exc = WebPushException("message", response)
print(exc) # WebPushException: messsage, Response response content
```

If you see some other places that could be changed in the scope of this PR, please let me know :smile:

I've also updated the test for `WebPushException`. I've relied on using `requests.Response` instead of `Mock`, to properly reflect the behaviour of `__bool__` method (instance of `Mock` was always truthy which gave false impression that the logic works properly).

One thing I'm not quite satisfied of is using "private" `_content` attribute of `requests.Response` instance to set the body of faked Response, since it's a part of private interface. Some alternatives I've been thinking of are:

- using some library to mock responses in tests (e.g. `responses`)
- still rely on `Mock` object, however also mock `__bool__` method return value to return False for 401 status code

Let me know if this needs some changes

## Testing

Simply run

```sh
python -m pytest pywebpush
```

as the test case was updated.

Testing manually:

- create `WebPushException`, pass a `Response` object and check it's string representation, e.g.

```python
response = Response()
response.status_code = 401
response._content = "response content".encode()
exc = WebPushException("message", response)
print(exc) # WebPushException: messsage, Response response content
```
