### PR TITLE
Use Licence classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,13 @@ name = "pywebpush"
 authors = [{ name = "JR Conlin", email = "src+webpusher@jrconlin.com" }]
 description = "WebPush publication library"
 readme = "README.md"
-# Use the LICENSE file for our license, since "MPL2" isn't included in the
-# canonical list
-license = { file = "LICENSE" }
 keywords = ["webpush", "vapid", "notification"]
 classifiers = [
     "Topic :: Internet :: WWW/HTTP",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
 ]
 # use the following fields defined in the setup.py file
 # (When the guides talk about something being "dynamic", they


### PR DESCRIPTION
## Description

Use licence classifiers as described in [python packaging guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license):

> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the classifiers starting with `License ::`. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)


In the [classifiers list](https://pypi.org/classifiers/) on PyPI it is listed:
> License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)


## Issue(s)

Closes #167
