### PR TITLE
Use unittest.mock

### DIFF
--- a/pywebpush/tests/test_webpush.py
+++ b/pywebpush/tests/test_webpush.py
@@ -4,11 +4,11 @@ import os
 import unittest
 import time
 from typing import cast, Union, Dict
+from unittest.mock import patch, Mock, AsyncMock
 
 import http_ece
 import py_vapid
 import requests
-from mock import patch, Mock, AsyncMock
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 black
-mock
 pytest


### PR DESCRIPTION
Drop the use of the external mock module, unittest.mock has been included in the standard library since Python 3.4.

Closes: #146