### PR TITLE
fix: remove dependency `six`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ aiohttp
 cryptography>=2.6.1
 http-ece>=1.1.0
 requests>=2.21.0
-six>=1.15.0
 py-vapid>=1.7.0


### PR DESCRIPTION
## Description

Remove dependency `six` from requirements.
Already removed with #189.
Not used.

## Testing

Search for usage.

## Issue(s)

Related to #189
Closes #166

