### PR TITLE
circleci: upgrade Python orb and use pinned python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,13 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@2.1.1
+  python: circleci/python@4.0.0
 
 jobs:
   build_and_test:
-    executor: python/default
+    executor:
+      name: python/default
+      tag: '3.10'
     steps:
       - checkout
       - python/install-packages:


### PR DESCRIPTION
## Description

Resolves python problem with circleci:
```txt
ERROR: Package 'pywebpush' requires a different Python: 3.8.20 not in '>=3.10'
```

Changes:

- upgrade Python orb 
- use pinned python version

Reference: https://circleci.com/developer/orbs/orb/circleci/python?version=4.0.0

## Testing

circleci should work and go green.

## Issue(s)

None
